### PR TITLE
Add backend dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# OpenFashion
+
+## Development Setup
+
+### Backend
+1. Create and activate a virtual environment:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install the required dependencies:
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+   This installs packages such as `openai`, `python-jose` and `passlib[bcrypt]` used by the API.
+3. Start the API server:
+   ```bash
+   uvicorn app.main:app --reload --app-dir backend/app
+   ```
+
+### Frontend
+See [`frontend/README.md`](frontend/README.md) for instructions on running the Next.js frontend.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,6 @@ pymongo
 fastapi
 uvicorn
 python-multipart
+openai
+python-jose
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- include `openai`, `python-jose`, and `passlib[bcrypt]` in backend requirements
- document backend setup and mention the new dependencies

## Testing
- `python -m pip install -r backend/requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ca0a03a68832694abfb0a0e2f7816