### PR TITLE
Add root README with setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,33 @@
 # OpenFashion
 
-## Development Setup
+OpenFashion is a full-stack fashion discovery platform consisting of a **FastAPI** backend and a **Next.js** frontend. The backend exposes REST endpoints for features like image analysis and style quizzes, while the frontend provides a responsive interface for exploring fashion inspiration.
 
-### Backend
-1. Create and activate a virtual environment:
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate
-   ```
-2. Install the required dependencies:
-   ```bash
-   pip install -r backend/requirements.txt
-   ```
-   This installs packages such as `openai`, `python-jose` and `passlib[bcrypt]` used by the API.
-3. Start the API server:
-   ```bash
-   uvicorn app.main:app --reload --app-dir backend/app
-   ```
+## Backend Setup
 
-### Frontend
-See [`frontend/README.md`](frontend/README.md) for instructions on running the Next.js frontend.
+```bash
+pip install -r backend/requirements.txt
+```
+
+Set the required environment variables (see [`backend/app/config/settings.py`](backend/app/config/settings.py)) for settings such as `SECRET_KEY`, `MONGO_URI`, `S3_BUCKET_NAME`, `OPENAI_API_KEY` and other API keys.
+
+Start the API server:
+
+```bash
+uvicorn app.main:app --reload --app-dir backend/app
+```
+
+## Frontend Setup
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Navigate to <http://localhost:3000> to view the app.
+
+## Features
+
+- **Image analysis** - analyze clothing images to generate search queries for similar items.
+- **Style quiz** - interactive quiz that builds a style profile and personalizes recommendations.
+- **Explore page** - browse recommended looks and save favorites.


### PR DESCRIPTION
## Summary
- document FastAPI/Next.js stack
- add backend and frontend setup instructions
- describe major features

## Testing
- `npm test` *(fails: missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca340d1a08326bca72b6455bcdbc2