### PR TITLE
Add dark mode toggle

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -7,12 +7,14 @@ import Link from "next/link"
 import "./globals.css"
 import { ShoppingBag, Menu, Heart } from "lucide-react"
 import { AuthProvider } from "@/contexts/AuthContext"
+import { ThemeProvider } from "@/contexts/ThemeContext"
 import { Toaster } from "sonner"
 import { NavLinks } from "@/components/NavLinks"
 import { UserAccountButton } from "@/components/UserAccountButton"
 import MobileNav from "@/components/MobileNav"
 import StyleChatbot from "@/components/ui/StyleChatbot"
 import PremiumBanner from '@/components/PremiumBanner'
+import ThemeToggle from '@/components/ThemeToggle'
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -28,6 +30,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         <link rel="icon" href="/favicon-32x32.png" type="image/x-icon" />
       </head>
       <body className={`${inter.className} antialiased min-h-screen bg-white`}>
+        <ThemeProvider>
         <AuthProvider>
           <PremiumBanner />
           <header className="fixed top-0 left-0 right-0 bg-white/80 backdrop-blur-sm z-40 border-b border-gray-100">
@@ -42,11 +45,12 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <Link href="/wishlist">
+                <Link href="/wishlist">
                     <button className="p-2 rounded-full hover:bg-gray-100 transition-colors">
                       <Heart className="h-5 w-5 text-gray-600" />
                     </button>
                   </Link>
+                  <ThemeToggle />
                   <div className="h-6 border-l border-gray-200 mx-2" />
                   <UserAccountButton />
                 </div>
@@ -77,6 +81,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           <MobileNav />
           <StyleChatbot />
         </AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/frontend/components/MobileNav.tsx
+++ b/frontend/components/MobileNav.tsx
@@ -1,8 +1,9 @@
 "use client"
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Search, Heart, User2, Shirt, MessageCircle } from "lucide-react";
+import { Home, Search, Heart, User2, Shirt, MessageCircle, Sun, Moon } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useTheme } from "@/contexts/ThemeContext";
 
 const navItems = [
   { href: "/", icon: Home, label: "Home" },
@@ -14,6 +15,7 @@ const navItems = [
 export default function MobileNav() {
   const pathname = usePathname();
   const { user } = useAuth();
+  const { theme, toggleTheme } = useTheme();
   
   // Add chat item if user is logged in
   const allNavItems = user ? [...navItems, { href: "/chat", icon: MessageCircle, label: "Chat" }] : navItems;
@@ -33,6 +35,17 @@ export default function MobileNav() {
           </Link>
         );
       })}
+      <button
+        onClick={toggleTheme}
+        className="flex flex-col items-center justify-center flex-1 h-full text-gray-500 hover:text-meta-pink"
+      >
+        {theme === 'dark' ? (
+          <Sun className="w-7 h-7 mb-1" />
+        ) : (
+          <Moon className="w-7 h-7 mb-1" />
+        )}
+        <span className="text-xs font-medium">{theme === 'dark' ? 'Light' : 'Dark'}</span>
+      </button>
     </nav>
   );
 } 

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,19 @@
+'use client'
+import { Moon, Sun } from 'lucide-react'
+import { useTheme } from '@/contexts/ThemeContext'
+import { Button } from '@/components/ui/button'
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+      className="rounded-full"
+    >
+      {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </Button>
+  )
+}

--- a/frontend/contexts/ThemeContext.tsx
+++ b/frontend/contexts/ThemeContext.tsx
@@ -1,0 +1,44 @@
+'use client'
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextType {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => {},
+})
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  useEffect(() => {
+    const stored = (typeof window !== 'undefined' && localStorage.getItem('theme')) as Theme | null
+    if (stored) {
+      setTheme(stored)
+      document.documentElement.classList.toggle('dark', stored === 'dark')
+    } else {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      if (prefersDark) {
+        setTheme('dark')
+        document.documentElement.classList.add('dark')
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('theme', theme)
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+  }, [theme])
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>
+}
+
+export const useTheme = () => useContext(ThemeContext)


### PR DESCRIPTION
## Summary
- add ThemeContext with persistence in localStorage
- create ThemeToggle component
- include ThemeProvider in app layout and add toggle button
- allow theme switching from mobile navigation as well

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'stripe')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fcdfaa7b48326904e269792a0141a